### PR TITLE
get only leaf dirs in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,6 @@ def all_dirs(location):
             output.append(valid_dir)
     return output
 
-print all_dirs('gisdata')
-
 setup(
     name="gisdata",
     version="0.4.2",


### PR DESCRIPTION
in geonode, pip install -e . (I updated geonode/setup.py's gisdata==0.4.2) was complaining w/ the following:

```
  Running setup.py install for gisdata
    error: can't copy 'gisdata/metadata/good': doesn't exist or not a regular file
    Complete output from command /home/tkralidi/venv/bin/python -c "import setuptools;__file__='/home/tkralidi/venv/build/gisdata/setup.py';exec(compile(open(__file__).read().replace('\r\n', '\n'), __file__, 'exec'))" install --single-version-externally-managed --record /tmp/pip-vJoWh2-record/install-record.txt --install-headers /home/tkralidi/venv/include/site/python2.6:
    running install

running build

running build_py

creating build

creating build/lib.linux-x86_64-2.6

creating build/lib.linux-x86_64-2.6/gisdata

copying gisdata/__init__.py -> build/lib.linux-x86_64-2.6/gisdata

creating build/lib.linux-x86_64-2.6/gisdata/metadata

error: can't copy 'gisdata/metadata/good': doesn't exist or not a regular file

```
